### PR TITLE
added automatic type inference

### DIFF
--- a/src/main/java/org/ruleml/oojdrew/parsing/generated/POSLParser.java
+++ b/src/main/java/org/ruleml/oojdrew/parsing/generated/POSLParser.java
@@ -23,6 +23,7 @@ import org.ruleml.oojdrew.util.DefiniteClause;
 import org.ruleml.oojdrew.util.SymbolTable;
 import org.ruleml.oojdrew.util.Term;
 import org.ruleml.oojdrew.util.Types;
+import org.ruleml.oojdrew.util.Util;
 
 import antlr.NoViableAltException;
 import antlr.ParserSharedInputState;
@@ -1251,19 +1252,7 @@ public POSLParser(ParserSharedInputState state) {
 			}
 			// automatic type inference<
 			if ( inputState.guessing==0 ) {
-				try {
-					Integer.parseInt(sym);
-					i.type = 2;
-				} catch (NumberFormatException e) {
-					//Symbol is no int. Try parsing to double.
-					try{
-						Double.parseDouble(sym);
-						i.type = 3;
-					} catch(NumberFormatException e2){
-						//Symbol is no double. We assign the String type
-						i.type = 4;
-					}
-				}
+				i.type=Util.getTypeForInference(sym);
 			}
 			//
 			{

--- a/src/main/java/org/ruleml/oojdrew/parsing/generated/POSLParser.java
+++ b/src/main/java/org/ruleml/oojdrew/parsing/generated/POSLParser.java
@@ -1249,6 +1249,23 @@ public POSLParser(ParserSharedInputState state) {
 				i = new Term(symid, SymbolTable.INOROLE, Types.IOBJECT);
 				
 			}
+			// automatic type inference<
+			if ( inputState.guessing==0 ) {
+				try {
+					Integer.parseInt(sym);
+					i.type = 2;
+				} catch (NumberFormatException e) {
+					//Symbol is no int. Try parsing to double.
+					try{
+						Double.parseDouble(sym);
+						i.type = 3;
+					} catch(NumberFormatException e2){
+						//Symbol is no double. We assign the String type
+						i.type = 4;
+					}
+				}
+			}
+			//
 			{
 			switch ( LA(1)) {
 			case DHAT:
@@ -1261,7 +1278,8 @@ public POSLParser(ParserSharedInputState state) {
 				break;
 			}
 			case COMMA:
-			case RPAREN:
+			case RPAREN: 
+				break;
 			case SEMI:
 			case HAT:
 			case PIPE:

--- a/src/main/java/org/ruleml/oojdrew/util/Util.java
+++ b/src/main/java/org/ruleml/oojdrew/util/Util.java
@@ -222,4 +222,22 @@ public class Util {
         bufferedWriter.write(content);
         bufferedWriter.close();
     }
+    
+    public static int getTypeForInference(String inputstring){
+    	int type = -1;
+		try {
+			Integer.parseInt(inputstring);
+			type = 2;
+		} catch (NumberFormatException e) {
+			//Symbol is no int. Try parsing to double.
+			try{
+				Double.parseDouble(inputstring);
+				type = 3;
+			} catch(NumberFormatException e2){
+				//Symbol is no double. We assign the String type
+				type = 4;
+			}
+		}
+		return type;
+    }
 }

--- a/src/test/java/org/ruleml/oojdrew/tests/TypeInfereceTest.java
+++ b/src/test/java/org/ruleml/oojdrew/tests/TypeInfereceTest.java
@@ -1,0 +1,26 @@
+package org.ruleml.oojdrew.tests;
+
+import org.ruleml.oojdrew.util.Util;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+public class TypeInfereceTest extends TestCase {
+	
+	
+	public static void testTypeInference(){
+				
+	    Assert.assertEquals(2, Util.getTypeForInference("1"));
+	    Assert.assertEquals(2, Util.getTypeForInference("1234"));
+	    Assert.assertEquals(2, Util.getTypeForInference("-5"));
+	    
+	    Assert.assertEquals(3, Util.getTypeForInference("1.0"));
+	    Assert.assertEquals(3, Util.getTypeForInference("1.234235"));
+	    Assert.assertEquals(3, Util.getTypeForInference("0.5"));
+	    
+	    Assert.assertEquals(4, Util.getTypeForInference("Hello World"));
+	    Assert.assertEquals(4, Util.getTypeForInference("twentythree"));
+	}
+	
+
+}


### PR DESCRIPTION
Instead of:

```
child(?person) :- hasAge(?person, ?age), lessThanOrEqual(?age, 18^^Integer).
hasAge(baby, 5^^Integer).
```

it would be easier if you could just write:

```
child(?person) :- hasAge(?person, ?age), lessThanOrEqual(?age, 18).
hasAge(baby, 5).
```

Supported data types are  integer, real and string.
